### PR TITLE
fix isCellNumeric for ngFor repeated cells

### DIFF
--- a/src/md-datatable-row.component.ts
+++ b/src/md-datatable-row.component.ts
@@ -95,7 +95,7 @@ export class MdDataTableRowComponent implements OnInit {
   isCellNumeric(cell: MdDataTableCellDirective) {
     let index = -1;
 
-    this.cells.find((cellItem, i) => {
+    this.cells && this.cells.find((cellItem, i) => {
         const match = cellItem === cell;
 
         if (match) {


### PR DESCRIPTION
Unfortunately does the `ContentChildren` query for `cells` not get instantiated before the method is called the first time, when using `ngFor`. Therefore it is necessary to check if `this.cells` is set.