### PR TITLE
Fix _datatable-theme.scss for latest material

### DIFF
--- a/src/_datatable-theme.scss
+++ b/src/_datatable-theme.scss
@@ -1,4 +1,4 @@
-@import '~@angular/material/core/theming/all-theme';
+@import '~@angular/material/theming';
 
 @include mat-core();
 


### PR DESCRIPTION
 - Update the import statement to work with @angular/material@2.0.0-beta.3