### PR TITLE
Fixing the material theme URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -106,7 +106,7 @@ Please read **src/md-datatable.interfaces.ts** for details about the payload of 
 To add `ng2-md-datatable` to your Material 2 theming file:
 
 ```scss
-@import '~ng2-md-datatable/datatable-theme';
+@import '~ng2-md-datatable/_datatable-theme.scss';
 ...
 @include mat-datatable-theme($theme);
 ```

--- a/src/lib/_datatable-theme.scss
+++ b/src/lib/_datatable-theme.scss
@@ -1,5 +1,4 @@
-@import '~@angular/material/core/theming/all-theme';
-
+@import '~@angular/material/_theming.scss';
 @include mat-core();
 
 @mixin mat-datatable-theme($theme) {


### PR DESCRIPTION
I made 2 changes the first to fix the compilation errors when using the module with the latest version of angular 