### PR TITLE
Fix mdIcon use proper material arrow icon instead of HTML ascii arrow

### DIFF
--- a/src/lib/md-datatable-column.component.scss
+++ b/src/lib/md-datatable-column.component.scss
@@ -12,22 +12,25 @@
     cursor: pointer;
   }
 
-  &.sorted-ascending > span, &.sorted-descending > span {
+  &.sortable > span {
     margin-right: 5px;
   }
 
-  &.sorted-ascending > span::before {
+  &.sortable > span::after {
+    visibility: hidden;
     font-family: 'Material Icons';
     vertical-align: sub;
-    padding-right: 5px;
-    content: '⬇';
+    padding-left: 5px;
+    content: '\E5DB';
   }
 
-  &.sorted-descending > span::before {
-    font-family: 'Material Icons';
-    vertical-align: sub;
-    padding-right: 5px;
-    content: '⬆';
+  &.sorted-ascending > span::after {
+    visibility: visible;
+  }
+
+  &.sorted-descending > span::after {
+    visibility: visible;
+    content: '\E5D8';
   }
 
   &.numeric {


### PR DESCRIPTION
Fix mdIcon use proper material arrow icon instead of HTML ascii basics arrow

Arrow icons align right to the column name and toggle visibility on hidden/visible to avoid the moving size of the table

![image](https://cloud.githubusercontent.com/assets/13983107/25093620/58450b76-2393-11e7-9603-a0d54988a4fe.png)
