### PR TITLE
Fixed that datatable’s EventEmitters would send one sort + selection …

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ng2-md-datatable",
-  "version": "1.3.5",
+  "version": "1.3.6",
   "description": "Angular 2 DataTable component for using with Material 2",
   "main": "dist/ng2-md-datatable/ng2-md-datatable.umd.js",
   "module": "dist/ng2-md-datatable/index.js",

--- a/src/demo-app/src/app/app.component.ts
+++ b/src/demo-app/src/app/app.component.ts
@@ -11,7 +11,6 @@ import { Subject } from 'rxjs/Subject';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { async } from 'rxjs/scheduler/async';
 import 'rxjs/add/observable/from';
-import 'rxjs/add/operator/do';
 import 'rxjs/add/operator/takeUntil';
 import { shuffle } from 'lodash-es';
 

--- a/src/lib/md-datatable.interfaces.ts
+++ b/src/lib/md-datatable.interfaces.ts
@@ -11,7 +11,7 @@ export interface IDatatableState {
   selectableValues: string[];
   selectedValues: string[];
   sortBy?: string;
-  sortType?: DatatableSortType;
+  sortType: DatatableSortType;
 }
 
 export interface IDatatablesState {
@@ -21,6 +21,16 @@ export interface IDatatablesState {
 export interface IDatatableReducer {
   reduce: (state: IDatatablesState, action: IDatatableAction) => IDatatablesState;
 }
+
+// Redux devtools proxy interfaces
+export interface IReduxDevToolsConnection {
+  init: (state: any) => void;
+  send: (action: any, state: any, options?: Object, instanceId?: string) => void;
+}
+
+export interface IReduxDevToolsExtension {
+  connect: (options: Object) => IReduxDevToolsConnection;
+};
 
 // public events
 export interface IDatatableSelectionEvent {

--- a/src/lib/md-datatable.module.ts
+++ b/src/lib/md-datatable.module.ts
@@ -1,19 +1,20 @@
 import { NgModule, Optional, SkipSelf } from '@angular/core';
 import { CommonModule } from '@angular/common';
-
-import { MdCheckboxModule, MdSelectModule, MdButtonModule, MdIconModule } from '@angular/material';
-
 import { FormsModule } from '@angular/forms';
+import { MdCheckboxModule, MdSelectModule, MdButtonModule, MdIconModule } from '@angular/material';
 
 import { MdDataTableComponent } from './md-datatable.component';
 import { MdDataTableHeaderComponent } from './md-datatable-header.component';
 import { MdDataTableColumnComponent } from './md-datatable-column.component';
 import { MdDataTableRowComponent } from './md-datatable-row.component';
 import { MdDataTablePaginationComponent } from './md-datatable-pagination.component';
+
 import {
   MdDatatableDispatcher,
   MdDatatableStore,
   STORE_INITIAL_STATE,
+  REDUX_DEVTOOLS_EXTENSION,
+  reduxDevToolsExtensionFactory,
 } from './md-datatable.store';
 import { DatatableReducer } from './md-datatable.reducer';
 import { MdDatatableActions } from './md-datatable.actions';
@@ -37,6 +38,7 @@ import { MdDatatableActions } from './md-datatable.actions';
   providers: [
     { provide: MdDatatableDispatcher, useClass: MdDatatableDispatcher },
     { provide: STORE_INITIAL_STATE, useValue: {} },
+    { provide: REDUX_DEVTOOLS_EXTENSION, useFactory: reduxDevToolsExtensionFactory },
     { provide: DatatableReducer, useClass: DatatableReducer },
     { provide: MdDatatableStore, useClass: MdDatatableStore },
     { provide: MdDatatableActions, useClass: MdDatatableActions },

--- a/src/lib/md-datatable.store.ts
+++ b/src/lib/md-datatable.store.ts
@@ -1,15 +1,35 @@
-import { Injectable, Inject, InjectionToken } from '@angular/core';
+import { Injectable, Inject, Optional, InjectionToken } from '@angular/core';
 import { Observable } from 'rxjs/Observable';
 import { BehaviorSubject } from 'rxjs/BehaviorSubject';
 import { async } from 'rxjs/scheduler/async';
 import 'rxjs/add/operator/observeOn';
 import 'rxjs/add/operator/withLatestFrom';
 
-import { IDatatablesState, IDatatableAction } from './md-datatable.interfaces';
+import {
+  IDatatablesState,
+  IDatatableAction,
+  IReduxDevToolsExtension,
+  IReduxDevToolsConnection,
+} from './md-datatable.interfaces';
+
 import { DatatableReducer } from './md-datatable.reducer';
 
 // For easing upgrading the library, I refrained myself of depending on @ngrx/store.
-// I chose the alternative if implementing a Redux Store in just these 50 LOC.
+// I chose the alternative of implementing a Redux Store in just these 50 LOC.
+
+export const STORE_INITIAL_STATE: InjectionToken<IDatatablesState> =
+  new InjectionToken('ng2-md-datatable-test-initial-state');
+
+export const REDUX_DEVTOOLS_EXTENSION: InjectionToken<IReduxDevToolsExtension> =
+  new InjectionToken('redux-devtools');
+
+export function reduxDevToolsExtensionFactory(): IReduxDevToolsExtension | null {
+  const REDUX_DEVTOOLS_KEY = '__REDUX_DEVTOOLS_EXTENSION__';
+
+  return typeof (window) === 'object' &&
+    typeof (window[REDUX_DEVTOOLS_KEY]) === 'function' ?
+    <IReduxDevToolsExtension>window[REDUX_DEVTOOLS_KEY] : null;
+}
 
 @Injectable()
 export class MdDatatableDispatcher extends BehaviorSubject<IDatatableAction> {
@@ -24,25 +44,52 @@ export class MdDatatableDispatcher extends BehaviorSubject<IDatatableAction> {
   }
 }
 
-export const STORE_INITIAL_STATE: InjectionToken<IDatatablesState> = new InjectionToken('ng2-md-datatable-test-initial-state');
-
 @Injectable()
 export class MdDatatableStore extends Observable<IDatatablesState> {
+  private instanceId = `ng2-md-datatable-store-${Date.now()}`;
   private state$: BehaviorSubject<IDatatablesState>;
 
   constructor(
     private dispatcher$: MdDatatableDispatcher,
     @Inject(STORE_INITIAL_STATE) initialState: IDatatablesState,
     reducer: DatatableReducer,
+    @Inject(REDUX_DEVTOOLS_EXTENSION) @Optional() reduxDevToolsExtension: IReduxDevToolsExtension,
   ) {
     super();
+
     this.state$ = new BehaviorSubject<IDatatablesState>(initialState);
     this.source = this.state$;
+    let reduxDevToolsConnection: IReduxDevToolsConnection;
+
+    if (reduxDevToolsExtension) {
+      reduxDevToolsConnection = reduxDevToolsExtension.connect({
+        name: this.instanceId,
+        features: {
+          pause: false,
+          lock: false,
+          persist: false,
+          export: true,
+          import: false,
+          jump: false,
+          skip: false,
+          reorder: false,
+          dispatch: false,
+          test: false,
+        },
+      });
+    }
 
     this.dispatcher$
       .withLatestFrom(this.source)
       .observeOn(async)
-      .subscribe(([action, state]) => this.state$.next(reducer.reduce(state, action)));
+      .subscribe(([action, state]) => {
+        const newState: IDatatablesState = reducer.reduce(state, action);
+        this.state$.next(newState);
+
+        if (reduxDevToolsConnection) {
+          reduxDevToolsConnection.send(action, newState, undefined, this.instanceId);
+        }
+      });
   }
 
   dispatch(action: IDatatableAction) {

--- a/src/lib/typings.d.ts
+++ b/src/lib/typings.d.ts
@@ -3,3 +3,4 @@
 // https://www.typescriptlang.org/docs/handbook/writing-declaration-files.html
 
 declare var System: any;
+declare interface Window { [key: string]: any };

--- a/tools/gulp/tasks/components.ts
+++ b/tools/gulp/tasks/components.ts
@@ -74,7 +74,6 @@ task(':build:components:rollup', [':build:components:inline'], () => {
     'rxjs/scheduler/async': 'Rx',
     'rxjs/add/observable/of': 'Rx.Observable',
     'rxjs/add/operator/distinctUntilChanged': 'Rx.Observable.prototype',
-    'rxjs/add/operator/do': 'Rx.Observable.prototype',
     'rxjs/add/operator/filter': 'Rx.Observable.prototype',
     'rxjs/add/operator/let': 'Rx.Observable.prototype',
     'rxjs/add/operator/map': 'Rx.Observable.prototype',
@@ -82,6 +81,7 @@ task(':build:components:rollup', [':build:components:inline'], () => {
     'rxjs/add/operator/observeOn': 'Rx.Observable.prototype',
     'rxjs/add/operator/pluck': 'Rx.Observable.prototype',
     'rxjs/add/operator/scan': 'Rx.Observable.prototype',
+    'rxjs/add/operator/skip': 'Rx.Observable.prototype',
     'rxjs/add/operator/takeUntil': 'Rx.Observable.prototype',
     'rxjs/add/operator/withLatestFrom': 'Rx.Observable.prototype',
   };


### PR DESCRIPTION
…event at startup. Added a hook for monitoring datatables states in Chrome Redux DevTools extension.